### PR TITLE
このイメージにPythonは不要でした

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -57,7 +57,6 @@ RUN rm -f /usr/local/bin/pecl /usr/local/bin/pear \
 
 COPY --from=composer/composer:lts /usr/bin/composer /usr/bin/composer
 
-RUN apk add --no-cache python3
 
 EXPOSE 80
 WORKDIR /app


### PR DESCRIPTION
Alpine版イメージにPythonを入れるようにしていましたが、これはテストコードを実行する可能性を考慮してでした。
でも実際のところ、別のテスト用のコンテナを並行して使うことになっているので不要なのを忘れていました。

ということでAlpine版のDockerfile(.alpine)からPythonのインストールコードを削除しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed Python 3 installation from the application image, resulting in a smaller and more streamlined deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->